### PR TITLE
Adds a new extended projects time feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "WORKLOG"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "jwt-decode": "^3.1.2",
         "uikit": "^3.16.21"
       },
       "devDependencies": {
@@ -8332,6 +8333,11 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -19270,6 +19276,11 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keyv": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "jwt-decode": "^3.1.2",
     "uikit": "^3.16.21"
   },
   "devDependencies": {

--- a/src/api/api-client.js
+++ b/src/api/api-client.js
@@ -1,0 +1,55 @@
+import jwtDecode from 'jwt-decode';
+
+const API_PREFIX = 'https://timedone.golden-dimension.com/backend/api';
+
+/**
+ * @typedef LogLine
+ * @type {object}
+ * @property {string} description log line description
+ * @property {string} logDate log line date in the yyyy-mm-dd format
+ * @property {number} timeUnit integer amount of time units,
+ *  1 unit is 30 minutes
+ * @property {Project} userProject
+ */
+
+/**
+ * @typedef Project
+ * @type {object}
+ * @property {string} projectName project name
+ */
+
+/**
+ * Fetches user lines for a current user
+ *
+ * @param {Date} dateFrom starting date to fetch the lines, should be in UTC
+ * @param {Date} dateTo ending date to fetch the lines, should be in UTC
+ * @return {Promise<Array<LogLine>>} promise for the log lines
+ */
+async function getUserLogLines(dateFrom, dateTo) {
+  const token = localStorage.access_token;
+  const userId = jwtDecode(token).sub;
+  const dateFromIso = toIsoDate(dateFrom);
+  const dateToIso = toIsoDate(dateTo);
+  const url = `${API_PREFIX}/v1/lines/users/${userId}` +
+   `?dateFrom=${dateFromIso}&dateTo=${dateToIso}`;
+
+  const response = await fetch(url, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Accept': 'application/json',
+    },
+  });
+
+  return await response.json();
+}
+
+/**
+ * Converts a date object into an ISO date string
+ * @param {Date} date date object to convert, should be in UTC
+ * @return {string} date string in the yyyy-mm-dd format
+ */
+function toIsoDate(date) {
+  return date.toISOString().split('T')[0];
+}
+
+export default {getUserLogLines};

--- a/src/feature/expand-all/expand-all.js
+++ b/src/feature/expand-all/expand-all.js
@@ -1,5 +1,6 @@
 import {ExpandCollapseElement} from './element/expand-collapse-element.js';
 import htmlHelper from '../../helper/html-helper.js';
+import extensionLogger from '../../helper/extension-logger.js';
 import './expand-all.css';
 
 const EXPAND_COLLAPSE_ELEMENT =
@@ -87,7 +88,8 @@ async function resolveHeaderCell() {
     return await htmlHelper.resolveElement(() =>
       document.querySelector('#head'));
   } catch (error) {
-    console.error(`Encountered an error on resolving header cell: %o`, error);
+    extensionLogger
+        .info(`Encountered an error on resolving header cell: %o`, error);
   }
 }
 

--- a/src/feature/feature-loader.js
+++ b/src/feature/feature-loader.js
@@ -3,12 +3,14 @@ import footerBackgroundFix from
   './footer-background-fix/footer-background-fix.js';
 import projectAutoselectBugfix from
   './project-autoselect-bugfix/project-autoselect-bugfix.js';
+import projectsTime from './projects-time/projects-time.js';
 
 /**
  * @typedef {import('./../feature/feature.js').Feature} Feature
  */
 
-const features = [expandAll, footerBackgroundFix, projectAutoselectBugfix];
+const features = [expandAll, footerBackgroundFix, projectAutoselectBugfix,
+  projectsTime];
 const featuresSorted = features.sort((first, second) =>
   first.getId().localeCompare(second.getId()));
 

--- a/src/feature/footer-background-fix/footer-background-fix.js
+++ b/src/feature/footer-background-fix/footer-background-fix.js
@@ -1,4 +1,6 @@
 import htmlHelper from '../../helper/html-helper.js';
+import extensionLogger from '../../helper/extension-logger.js';
+
 import './footer-background-fix.css';
 
 let initialized = false;
@@ -62,7 +64,7 @@ async function resolveFooterElement() {
     return await htmlHelper.resolveElement(() =>
       document.querySelector('div.worklog__footer'));
   } catch (error) {
-    console.error(`Encountered an error on resolving footer element: %o`,
+    extensionLogger.info(`Encountered an error on resolving footer element: %o`,
         error);
   }
 }

--- a/src/feature/project-autoselect-bugfix/project-autoselect-bugfix.js
+++ b/src/feature/project-autoselect-bugfix/project-autoselect-bugfix.js
@@ -1,4 +1,5 @@
 import htmlHelper from '../../helper/html-helper.js';
+import extensionLogger from '../../helper/extension-logger.js';
 
 const PROJECT_SELECT_ELEMENT_SELECTOR = 'app-manage-worklog select#projectId';
 const FIRST_PROJECT_SELECT_OPTION_ELEMENT_SELECTOR =
@@ -64,7 +65,7 @@ async function tryAutoselectProjectIfNoneSelected() {
     projectSelectElement = await htmlHelper.resolveElement(() =>
       document.querySelector(PROJECT_SELECT_ELEMENT_SELECTOR));
   } catch (error) {
-    console.error(`Encountered an error on autoselecting a project when
+    extensionLogger.info(`Encountered an error on autoselecting a project when
      resolving selection element: %o`, error);
   }
 

--- a/src/feature/projects-time/data/projects-time-data-storage.js
+++ b/src/feature/projects-time/data/projects-time-data-storage.js
@@ -1,0 +1,48 @@
+import storageService from '../../../helper/storage-service.js';
+
+const REGEX_DATA_STORAGE_KEY = 'regex';
+
+/**
+ * Returns grouping regex value by the provided project
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} projectName project name to get the grouping regex for
+ * @return {Promise<string>} promise for the grouping regex value for the
+ *  project, if it exists
+ */
+async function getGroupRegexByProject(featureId, projectName) {
+  const storedRegexData = await storageService.getFeatureData(featureId,
+      REGEX_DATA_STORAGE_KEY);
+  const projectKey = convertProjectNameToKey(projectName);
+
+  return storedRegexData[projectKey];
+}
+
+/**
+ * Saves grouping regex value for the provided project
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} projectName project name to save the grouping regex for
+ * @param {string} newRegexValue grouping regex value to save
+ */
+async function saveGroupRegexForProject(featureId, projectName, newRegexValue) {
+  const projectKey = convertProjectNameToKey(projectName);
+  const regexData = await storageService.getFeatureData(featureId,
+      REGEX_DATA_STORAGE_KEY);
+
+  regexData[projectKey] = newRegexValue;
+
+  storageService.storeFeatureData(featureId, REGEX_DATA_STORAGE_KEY, regexData);
+}
+
+/**
+ * Converts the provided project name into a storage key
+ *
+ * @param {string} projectName name
+ * @return {string} converted project storage key
+ */
+function convertProjectNameToKey(projectName) {
+  return projectName.replaceAll(' ', '-');
+}
+
+export default {getGroupRegexByProject, saveGroupRegexForProject};

--- a/src/feature/projects-time/element/projects-time-element-builder.js
+++ b/src/feature/projects-time/element/projects-time-element-builder.js
@@ -1,0 +1,421 @@
+import dataStorage from '../data/projects-time-data-storage.js';
+import UIkit from 'uikit';
+
+const PROJECT_GROUPS_CONTAINER_ID_PREFIX = 'tes-pt-project-groups-';
+const PROJECT_GROUP_TITLE_CLASS = 'tes-pt-group-title';
+const FORM_ERROR_CLASS = 'uk-form-danger';
+const ACCORDION_CONTENT_CLASS = 'uk-accordion-content';
+const ACCORDION_TITLE_CLASS = 'uk-accordion-title';
+const DEFAULT_LOG_GROUP_NAME = 'Ungrouped';
+const EMPTY_REGEX_PLACEHOLDER = 'Regex';
+const REGEX_INPUT_TOOLTIP = 'Регулярний вираз для групування записів.<br>' +
+  'Має містити рівно одну групу захоплення.';
+const REGEX_INPUT_ERROR_MESSAGE_PREFIX = 'Помилка в регулярному виразі. ';
+const REGEX_MISSING_GROUP_ERROR = 'Вираз має містити групу захоплення';
+const regexTooManyGroupsErrorMessageGenerator = (groupsAmount) =>
+  `Забагато груп захоплення в виразі: реальна кількість - ${groupsAmount}, ` +
+   'очікувана - 1';
+
+/**
+ * @typedef {import('./../../../api/api-client.js').LogLine} LogLine
+ */
+
+/**
+ * Function that groups log lines by a grouping key
+ *
+ * @callback linesGroupingFunction
+ * @param {string} projectName name of the project, associated with the
+ * log lines
+ * @param {Array<LogLine>} logLines log lines to group
+ * @return {Promise<Map<string, Array<LogLine>>>} promise for the log lines
+ *  grouped by a grouping key
+ */
+
+/**
+ * Builds project container
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {HTMLElement} worklogProjectElement original worklog project element
+ * @param {string} projectName name of the project
+ * @param {Array<LogLine>} logLines log line entries
+ * @param {linesGroupingFunction} groupLogLinesByGroupKey lines grouping
+ *  function
+ * @param {string} projectTitleClass name of the project title element CSS class
+ * @param {string} projectAccordionTitleClass name of the accordion title
+ *  element CSS class for the project title element
+ * @return {Promise<HTMLDivElement>} promise for the project container
+ */
+async function buildProjectContainer(featureId, worklogProjectElement,
+    projectName, logLines, groupLogLinesByGroupKey, projectTitleClass,
+    projectAccordionTitleClass) {
+  const newProjectContainer = document.createElement('div');
+
+  const projectAccordionTitleElement = document.createElement('div');
+  projectAccordionTitleElement.classList.add(projectAccordionTitleClass);
+  newProjectContainer.append(projectAccordionTitleElement);
+  worklogProjectElement.classList.add(projectTitleClass);
+  projectAccordionTitleElement.append(worklogProjectElement);
+
+  const projectDetails = document.createElement('div');
+  projectDetails.classList.add(ACCORDION_CONTENT_CLASS);
+
+  const groupRegexContainer = document.createElement('div');
+  groupRegexContainer.classList.add('uk-flex', 'uk-flex-right');
+  const groupRegexFormContainer = document.createElement('div');
+  groupRegexFormContainer.classList.add('uk-inline', 'uk-margin-small-bottom');
+
+  const groupRegexInputElement = await buildRegexInputElement(featureId,
+      projectName, logLines, groupLogLinesByGroupKey);
+  groupRegexFormContainer.append(groupRegexInputElement);
+  const groupRegexIconElement = document.createElement('button');
+  groupRegexIconElement.classList.add('uk-form-icon', 'uk-form-icon-flip');
+  groupRegexIconElement.setAttribute('uk-icon', 'icon: info');
+  groupRegexIconElement.setAttribute('uk-tooltip', REGEX_INPUT_TOOLTIP);
+  groupRegexFormContainer.append(groupRegexIconElement);
+
+  groupRegexContainer.append(groupRegexFormContainer);
+  projectDetails.append(groupRegexContainer);
+
+  const projectGroups = await buildProjectGroupsContainer(projectName,
+      logLines, groupLogLinesByGroupKey);
+  projectDetails.append(projectGroups);
+  newProjectContainer.append(projectDetails);
+
+  return newProjectContainer;
+}
+
+/**
+ * Creates a regex input element for the project
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} projectName name of the project
+ * @param {Array<LogLine>} logLines log line entries
+ * @param {Function} groupLogLinesByGroupKey function
+ * @return {Promise<HTMLInputElement>} promise for the regex input element
+ */
+async function buildRegexInputElement(featureId, projectName,
+    logLines, groupLogLinesByGroupKey) {
+  const groupRegexElement = document.createElement('input');
+  groupRegexElement.classList.add('uk-input', 'uk-form-small',
+      'uk-form-width-small');
+  groupRegexElement.placeholder = EMPTY_REGEX_PLACEHOLDER;
+  groupRegexElement.addEventListener('change',
+      (changeEvent) => handleProjectRegexChange(featureId, projectName,
+          changeEvent, logLines, groupLogLinesByGroupKey));
+
+  const savedGroupRegex =
+    await dataStorage.getGroupRegexByProject(featureId, projectName);
+  groupRegexElement.value = savedGroupRegex || '';
+
+  return groupRegexElement;
+}
+
+/**
+ * Creates a container with grouped project log entries
+ *
+ * @param {string} projectName name of the project
+ * @param {Array<LogLine>} logLines log line entries
+ * @param {linesGroupingFunction} groupLogLinesByGroupKey lines grouping
+ *  function
+ * @return {Promise<HTMLDivElement>} promise for the project groups container
+ */
+async function buildProjectGroupsContainer(projectName, logLines,
+    groupLogLinesByGroupKey) {
+  const projectGroups = document.createElement('div');
+  const projectElementId = convertProjectNameToElementId(projectName);
+  projectGroups.id = PROJECT_GROUPS_CONTAINER_ID_PREFIX + projectElementId;
+
+  const groupContainers = await buildProjectGroupContainers(projectName,
+      logLines, groupLogLinesByGroupKey);
+  projectGroups.append(...groupContainers);
+
+  return projectGroups;
+}
+
+/**
+ * Creates group containers for all log entry groups
+ *
+ * @param {string} projectName name of the project
+ * @param {Array<LogLine>} logLines log line entries
+ * @param {linesGroupingFunction} groupLogLinesByGroupKey lines grouping
+ *  function
+ * @return {Promise<Array<HTMLDivElement>>} promise for the project group
+ *  containers
+ */
+async function buildProjectGroupContainers(projectName, logLines,
+    groupLogLinesByGroupKey) {
+  const logLinesByGroupingKey = await groupLogLinesByGroupKey(projectName,
+      logLines);
+  const logLinesByGroupingKeySorted = new Map([...logLinesByGroupingKey]
+      .sort((firstEntry, secondEntry) =>
+        String(firstEntry[0]).localeCompare(secondEntry[0])));
+
+  return Array.from(logLinesByGroupingKeySorted, ([groupName, logLines]) =>
+    buildProjectGroupContainer(logLines, groupName));
+}
+
+/**
+ * Handles the project regex value change event
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} projectName name of the project, associated with the regex
+ * @param {Event} event change event
+ * @param {Array<LogLine>} logLines log line entries
+ * @param {Function} groupLogLinesByGroupKey function
+ */
+async function handleProjectRegexChange(featureId, projectName, event,
+    logLines, groupLogLinesByGroupKey) {
+  const inputElement = event.target;
+  const regexFromUser = inputElement.value;
+  const validRegex = validateRegexValue(regexFromUser, inputElement);
+  if (!validRegex) {
+    return;
+  }
+
+  await dataStorage.saveGroupRegexForProject(featureId, projectName,
+      regexFromUser);
+  regenerateProjectGroups(projectName, logLines, groupLogLinesByGroupKey);
+}
+
+/**
+ * Validates regex value input
+ *
+ * Provides an error to the user on invalid input value
+ *
+ * @param {string} regexValue regex value provided by the user
+ * @param {HTMLInputElement} regexInputElement regex HTML input element
+ * @return {boolean} whether the user provided regex is valid or not
+ */
+function validateRegexValue(regexValue, regexInputElement) {
+  const regexError = getInvalidRegexError(regexValue);
+
+  if (regexError) {
+    regexInputElement.setCustomValidity(REGEX_INPUT_ERROR_MESSAGE_PREFIX +
+      regexError);
+    regexInputElement.classList.add(FORM_ERROR_CLASS);
+
+    setTimeout(() => {
+      regexInputElement.reportValidity();
+    }, 0);
+
+    return false;
+  }
+
+  regexInputElement.setCustomValidity('');
+  regexInputElement.classList.remove(FORM_ERROR_CLASS);
+
+  return true;
+}
+
+/**
+ * Gets an error on invalid regex value
+ *
+ * @param {string} regexValue regex value string
+ * @return {Error} error if the regex is invalid or null if it's valid
+ */
+function getInvalidRegexError(regexValue) {
+  if (regexValue === '') {
+    return null;
+  }
+
+  const regexSyntaxError = validateRegexValueSyntax(regexValue);
+  if (regexSyntaxError) {
+    return regexSyntaxError;
+  }
+
+  return validateRegexGroupsAmount(regexValue);
+}
+
+/**
+ * Validates the regex value syntax
+ *
+ * @param {string} regexValue regex value string to be validated
+ * @return {Error} error if the value can't be parsed as a valid regex,
+ *  or null if it's valid
+ */
+function validateRegexValueSyntax(regexValue) {
+  try {
+    new RegExp(regexValue);
+  } catch (e) {
+    return e;
+  }
+}
+
+/**
+ * Validates the amount of capturing groups in the regex
+ *
+ * @param {string} regexValue regex value string to be validated
+ * @return {Error} error if the regex value contains an invalid amount of
+ *  groups, or null if it's valid
+ */
+function validateRegexGroupsAmount(regexValue) {
+  const regexMatchingEmptyString = new RegExp(regexValue + '|');
+  const capturingGroupsAmount = regexMatchingEmptyString.exec('').length - 1;
+
+  if (capturingGroupsAmount === 1) {
+    return null;
+  }
+
+  if (capturingGroupsAmount === 0) {
+    return new Error(REGEX_MISSING_GROUP_ERROR);
+  }
+
+  const message =
+    regexTooManyGroupsErrorMessageGenerator(capturingGroupsAmount);
+  return new Error(message);
+}
+
+/**
+ * Regenerates project groups element
+ *
+ * Replaces existing project groups with new ones, designed for usage after
+ *  changing the grouping key
+ *
+ * @param {string} projectName name of the project, associated with the regex
+ * @param {Array<LogLine>} logLines log line entries
+ * @param {Function} groupLogLinesByGroupKey function
+ */
+async function regenerateProjectGroups(projectName, logLines,
+    groupLogLinesByGroupKey) {
+  const projectElementId = convertProjectNameToElementId(projectName);
+  const selector = '#' + PROJECT_GROUPS_CONTAINER_ID_PREFIX + projectElementId;
+  const projectGroupsContainer = document.querySelector(selector);
+  if (!projectGroupsContainer) {
+    return;
+  }
+
+  const projectGroups = await buildProjectGroupContainers(projectName, logLines,
+      groupLogLinesByGroupKey);
+
+  projectGroupsContainer.replaceChildren(...projectGroups);
+}
+
+/**
+ * Creates a container for a single project group
+ *
+ * @param {Array<LogLine>} logLines log lines, associated with the group
+ * @param {string} groupName name of the group
+ * @return {HTMLDivElement} project group container
+ */
+function buildProjectGroupContainer(logLines, groupName) {
+  const groupSummaryContainer =
+    buildGroupSummaryContainer(logLines, groupName);
+
+  const groupTitleElement = document.createElement('a');
+  groupTitleElement.classList.add(ACCORDION_TITLE_CLASS);
+  groupTitleElement.append(groupSummaryContainer);
+
+  const accordionElement = document.createElement('ul');
+  accordionElement.classList.add('uk-list');
+
+  const accordionEntryElement = document.createElement('li');
+  accordionEntryElement.append(groupTitleElement);
+  const groupDetailsContainer = document.createElement('div');
+  groupDetailsContainer.classList.add(ACCORDION_CONTENT_CLASS,
+      'uk-flex', 'uk-flex-column');
+  logLines.forEach((entry) => {
+    const logLineElement = buildLogLineContainer(entry);
+    groupDetailsContainer.append(logLineElement);
+  });
+  accordionEntryElement.append(groupDetailsContainer);
+
+  accordionElement.append(accordionEntryElement);
+  UIkit.accordion(accordionElement);
+
+  const groupContainer = document.createElement('div');
+  groupContainer.append(accordionElement);
+
+  return groupContainer;
+}
+
+/**
+ * Creates a group summary container
+ *
+ * @param {Array<LogLine>} logLines log lines, associated with the group
+ * @param {string} groupName name of the group
+ * @return {HTMLDivElement} group summary container
+ */
+function buildGroupSummaryContainer(logLines, groupName) {
+  const groupSummaryContainer = document.createElement('div');
+  groupSummaryContainer.classList.add('uk-flex', 'uk-flex-column');
+
+  const groupSummaryTitleElement = document.createElement('span');
+  groupSummaryTitleElement.classList.add(PROJECT_GROUP_TITLE_CLASS);
+  const groupTitle = groupName !== null ? groupName : DEFAULT_LOG_GROUP_NAME;
+  groupSummaryTitleElement.innerHTML = groupTitle;
+  groupSummaryContainer.append(groupSummaryTitleElement);
+
+  const groupTimeElement = document.createElement('span');
+  const totalGroupTimeUnits = logLines.reduce((accumulator, entry) =>
+    accumulator + entry.timeUnit, 0);
+  const localizedTimeString = timeUnitsToString(totalGroupTimeUnits);
+  groupTimeElement.innerHTML = localizedTimeString;
+  groupTimeElement.classList.add('uk-text-normal', 'uk-text-default');
+
+  groupSummaryContainer.append(groupTimeElement);
+
+  return groupSummaryContainer;
+}
+
+/**
+ * Creates a log line container
+ *
+ * @param {LogLine} logLine log line
+ * @return {HTMLDivElement} log line container
+ */
+function buildLogLineContainer(logLine) {
+  const container = document.createElement('div');
+  container.classList.add('uk-flex', 'uk-flex-column', 'uk-margin-small');
+  const logDescription = document.createElement('span');
+  logDescription.innerHTML = logLine.description;
+  container.append(logDescription);
+
+  const logLineDetailsElement = document.createElement('span');
+  const logDurationString = timeUnitsToString(logLine.timeUnit);
+  const logDateString = isoDateToString(logLine.logDate);
+  const logLineDetails = `${logDurationString} | ${logDateString}`;
+  logLineDetailsElement.innerHTML = logLineDetails;
+  logLineDetailsElement.classList.add('uk-text-meta');
+  container.append(logLineDetailsElement);
+
+  return container;
+}
+
+/**
+ * Converts time units into human-readable duration
+ *
+ * @param {number} timeUnits integer amount of work log time units, 1 unit is 30
+ *  minutes
+ * @return {string} localized duration string
+ */
+function timeUnitsToString(timeUnits) {
+  const hours = Math.floor(timeUnits / 2);
+  const minutes = timeUnits % 2 * 30;
+
+  return hours + ' год. ' + minutes + ' хв.';
+}
+
+/**
+ * Converts the provided ISO date string into a human-readable one
+ *
+ * @param {string} isoDateString date string in the yyyy-mm-dd format
+ * @return {string} localized date string
+ */
+function isoDateToString(isoDateString) {
+  const dateParts = isoDateString.split('-');
+  const utcDate = new Date(Date.UTC(dateParts[0], dateParts[1], dateParts[2]));
+
+  return utcDate.toLocaleDateString('uk-UA');
+}
+
+/**
+ * Converts the provided project name into an element ID
+ *
+ * @param {string} projectName name
+ * @return {string} converted project element ID
+ */
+function convertProjectNameToElementId(projectName) {
+  return projectName.replaceAll(' ', '-');
+}
+
+export default {buildProjectContainer};

--- a/src/feature/projects-time/projects-time.css
+++ b/src/feature/projects-time/projects-time.css
@@ -1,0 +1,32 @@
+.tes-pt-accordion-title::before {
+  content: "";
+  width: 1em;
+  height: 1em;
+  margin-left: 10px;
+  float: right;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%20%20%3Crect%20fill%3D%22%23666%22%20width%3D%2213%22%20height%3D%221%22%20x%3D%220%22%20y%3D%226%22%20%2F%3E%0A%20%20%20%20%3Crect%20fill%3D%22%23666%22%20width%3D%221%22%20height%3D%2213%22%20x%3D%226%22%20y%3D%220%22%20%2F%3E%0A%3C%2Fsvg%3E");
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+}
+
+.uk-open > .tes-pt-accordion-title::before {
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%20%20%3Crect%20fill%3D%22%23666%22%20width%3D%2213%22%20height%3D%221%22%20x%3D%220%22%20y%3D%226%22%20%2F%3E%0A%3C%2Fsvg%3E");
+}
+
+.tes-pt-accordion-title > .worklog-project {
+  padding: 0;
+  margin: 0.75rem 0;
+}
+
+.tes-pt-modal-container {
+  width: 75rem;
+  max-height: 75rem;
+}
+
+.tes-pt-group-title {
+  font-size: 1.1rem;
+}
+
+.tes-pt-project-title {
+  font-size: 1.2rem;
+}

--- a/src/feature/projects-time/projects-time.js
+++ b/src/feature/projects-time/projects-time.js
@@ -1,0 +1,373 @@
+import apiClient from '../../api/api-client.js';
+import htmlHelper from '../../helper/html-helper.js';
+import elementBuilder from './element/projects-time-element-builder.js';
+import dataStorage from './data/projects-time-data-storage.js';
+import extensionLogger from '../../helper/extension-logger.js';
+import UIkit from 'uikit';
+import './projects-time.css';
+
+const OVERLAY_MUTATION_OBSERVER = new MutationObserver(
+    () => triggerProjectsTimeModification());
+
+const PROJECTS_TIME_ELEMENT_SELECTOR = 'app-worklog-projects-time';
+const OVERLAY_CONTAINER_SELECTOR = '.cdk-overlay-container';
+const CUSTOM_MODAL_CONTAINER_CLASS = 'tes-pt-modal-container';
+const PROJECTS_TIME_MODAL_CONTAINER_SELECTOR = 'mat-dialog-container';
+const DATE_FROM_PICKER_SELECTOR = 'input#dateFrom';
+const DATE_TO_PICKER_SELECTOR = 'input#dateTo';
+const WORKLOG_PROJECT_CLASS = '.worklog-project';
+const ACCORDION_CLASS = 'uk-accordion';
+const PROJECT_ACCORDION_TITLE_CLASS = 'tes-pt-accordion-title';
+const PROJECT_TITLE_CLASS = 'tes-pt-project-title';
+
+let initialized = false;
+
+/**
+ * Returns a unique feature identifier
+ * @return {string} feature ID
+ */
+function getId() {
+  return 'projects-time';
+}
+
+/**
+ * Returns a feature description
+ *
+ * @return {string} feature description
+ */
+function getDescription() {
+  return 'Extend the projects time summary page';
+}
+
+/**
+ * Returns whether the feature has been initialized
+ *
+ * @return {boolean} feature initialization status
+ */
+function isInitialized() {
+  return initialized;
+}
+
+/**
+ * Initializes and enables the feature
+ */
+async function initialize() {
+  triggerProjectsTimeModification();
+
+  initialized = true;
+}
+
+/**
+ * Deregisters and disables the feature
+ */
+async function deregister() {
+  disableOverlayObserver();
+  removeCustomModalClass();
+  restoreProjectsTimeTable();
+
+  initialized = false;
+}
+
+/**
+ * Enables overlay mutation observer
+ */
+function enableOverlayObserver() {
+  const overlayElement = document.querySelector(OVERLAY_CONTAINER_SELECTOR);
+  OVERLAY_MUTATION_OBSERVER.observe(overlayElement, {childList: true});
+}
+
+/**
+ * Disables overlay mutation observer
+ */
+function disableOverlayObserver() {
+  OVERLAY_MUTATION_OBSERVER.disconnect();
+}
+
+/**
+ * Triggers the modification of the projects time window
+ */
+async function triggerProjectsTimeModification() {
+  disableOverlayObserver();
+
+  await modifyProjectsTimeModal();
+
+  enableOverlayObserver();
+}
+
+/**
+ * Modifies the existing projects time modal window
+ */
+async function modifyProjectsTimeModal() {
+  const projectsTimeElement =
+    await resolveElement(PROJECTS_TIME_ELEMENT_SELECTOR);
+
+  if (!projectsTimeElement) {
+    return;
+  }
+
+  await Promise.all([assignCustomModalClass(), modifyProjectsTimeEntries()]);
+}
+
+/**
+ * Assigns custom class to the modal container
+ */
+async function assignCustomModalClass() {
+  const projectsTimeModalElement =
+    await resolveElement(PROJECTS_TIME_MODAL_CONTAINER_SELECTOR);
+  if (!projectsTimeModalElement) {
+    return;
+  }
+
+  projectsTimeModalElement.classList.add(CUSTOM_MODAL_CONTAINER_CLASS);
+}
+
+/**
+ * Removes custom class from the modal container
+ */
+async function removeCustomModalClass() {
+  const modalContainer =
+    await resolveElement(`.${CUSTOM_MODAL_CONTAINER_CLASS}`);
+  if (!modalContainer) {
+    return;
+  }
+
+  modalContainer.classList.remove(CUSTOM_MODAL_CONTAINER_CLASS);
+}
+
+/**
+ * Restore original projects time table
+ */
+async function restoreProjectsTimeTable() {
+  const tableElementSelector =
+    `${PROJECTS_TIME_ELEMENT_SELECTOR} .${ACCORDION_CLASS}`;
+  const projectsTableElement = await resolveElement(tableElementSelector);
+  if (!projectsTableElement) {
+    return;
+  }
+  projectsTableElement.classList.remove(ACCORDION_CLASS);
+
+  const projectTitleElements = await resolveElements(`.${PROJECT_TITLE_CLASS}`);
+  if (!projectTitleElements) {
+    return;
+  }
+  projectTitleElements.forEach((element) =>
+    element.classList.remove(PROJECT_TITLE_CLASS));
+  projectsTableElement.replaceChildren(...projectTitleElements);
+}
+
+/**
+ * Modifies the existing projects time entries
+ *
+ * @return {Promise<void>} promise for the operation completion
+ */
+async function modifyProjectsTimeEntries() {
+  const logLines = await getLogLineEntries();
+
+  const logLinesByProjectName = groupToMap(logLines,
+      (logLine) => logLine.userProject.projectName);
+  const logLinesByProjectNameSorted = new Map([...logLinesByProjectName]
+      .sort((firstEntry, secondEntry) =>
+        String(firstEntry[0]).localeCompare(secondEntry[0])));
+
+  const modificationPromises = [];
+  for (const [projectName, logLines] of logLinesByProjectNameSorted) {
+    const projectElement = await htmlHelper.resolveElement(() =>
+      findWorklogProjectElement(projectName));
+    const modificationPromise = modifyProjectTimeDetails(projectElement,
+        projectName, logLines);
+    modificationPromises.push(modificationPromise);
+  }
+
+  await Promise.all(modificationPromises);
+}
+
+/**
+ * @typedef {import('./../../api/api-client.js').LogLine} LogLine
+ */
+
+/**
+ * Returns all log line entries for the currently selected dates
+ *
+ * @return {Promise<Array<LogLine>>} promise for the log lines
+ */
+async function getLogLineEntries() {
+  const [dateFromElement, dateToElement] = await Promise.all([
+    resolveElement(DATE_FROM_PICKER_SELECTOR),
+    resolveElement(DATE_TO_PICKER_SELECTOR)]);
+
+  if (!dateFromElement || !dateToElement) {
+    return;
+  }
+
+  const dateFrom = localStringToDate(dateFromElement.value);
+  const dateTo = localStringToDate(dateToElement.value);
+
+  return await apiClient.getUserLogLines(dateFrom, dateTo);
+}
+
+/**
+ * Function that extracts the key from an object
+ *
+ * @callback keyExtractor
+ * @param {T} object object to extract the key from
+ * @return {K} extracted key`
+ * @template T, K
+ */
+
+/**
+ * Groups the array into a map by an extracted key
+ *
+ * @param {Array<T>} array array to be grouped
+ * @param {keyExtractor<T, K>} keyExtractor key extractor
+ * @return {Map<K, Array<T>>} grouped map
+ * @template T, K
+ */
+function groupToMap(array, keyExtractor) {
+  return array.reduce((map, arrayElement) => {
+    const key = keyExtractor(arrayElement);
+    map.get(key)?.push(arrayElement) ?? map.set(key, [arrayElement]);
+    return map;
+  }, new Map());
+}
+
+/**
+ * Groups log lines by a grouping key
+ *
+ * Grouping key is extracted by a regular expression, associated with the
+ *  project. Two log line entries will be grouped together if regular expression
+ *  matches the same substring in the line description.
+ *
+ * @param {string} projectName name of the project, associated with the
+ * log lines
+ * @param {Array<LogLine>} logLines log lines to group
+ * @return {Promise<Map<string, Array<LogLine>>>} promise for the log lines
+ *  grouped by a grouping key
+ */
+async function groupLogLinesByGroupKey(projectName, logLines) {
+  const groupRegexValue = await dataStorage.getGroupRegexByProject(getId(),
+      projectName);
+  const groupRegex = groupRegexValue ? new RegExp(groupRegexValue) : null;
+
+  return groupLogLinesByRegex(logLines, groupRegex);
+}
+
+/**
+ * Groups log lines by a regex grouping key
+ *
+ * @param {Array<LogLine>} logLines log lines to group
+ * @param {RegExp} regex regular expression for extracting the grouping key
+ * @return {Promise<Map<string, Array<LogLine>>>} promise for the log lines
+ *  grouped by a grouping key
+ */
+function groupLogLinesByRegex(logLines, regex) {
+  return groupToMap(logLines, (logLine) => extractGroupingKey(logLine, regex));
+}
+
+/**
+ * Extracts the grouping key from the log line entry
+ *
+ * @param {LogLine} logLine log line to extract the group from
+ * @param {RegExp} regex regular expression for extracting the grouping key
+ * @return {string | null} extracted grouping key or null if it couldn't be
+ *  extracted
+ */
+function extractGroupingKey(logLine, regex) {
+  if (regex == null) {
+    return null;
+  }
+
+  const description = logLine.description.trim();
+  const matchedResults = regex.exec(description);
+
+  if (matchedResults == null || matchedResults.length < 2) {
+    return null;
+  }
+
+  return matchedResults[1];
+}
+
+/**
+ * Finds a worklog project element by the project name
+ *
+ * @param {string} projectName project name to search the element by
+ * @return {HTMLElement | undefined} worklog project element
+ */
+function findWorklogProjectElement(projectName) {
+  const matchingElements = document.querySelectorAll(WORKLOG_PROJECT_CLASS);
+
+  const matchingElement = Array.from(matchingElements)
+      .find((element) => {
+        if (element.hasChildNodes() &&
+          element.firstChild.textContent === projectName) {
+          return element;
+        }
+      });
+
+  return matchingElement;
+}
+
+/**
+ * Modifies time details element for the provided project
+ *
+ * @param {HTMLElement} worklogProjectElement original worklog project element
+ * @param {string} projectName name of the project
+ * @param {Array<LogLine>} logLines log line entries
+ */
+async function modifyProjectTimeDetails(worklogProjectElement, projectName,
+    logLines) {
+  const originalProjectsTable = worklogProjectElement.parentElement;
+  const newProjectContainer =
+    await elementBuilder.buildProjectContainer(getId(), worklogProjectElement,
+        projectName, logLines, groupLogLinesByGroupKey, PROJECT_TITLE_CLASS,
+        PROJECT_ACCORDION_TITLE_CLASS);
+  originalProjectsTable.append(newProjectContainer);
+
+  UIkit.accordion(originalProjectsTable,
+      {multiple: true, toggle: `> .${PROJECT_ACCORDION_TITLE_CLASS}`});
+}
+
+/**
+ * Converts a localized string value into a date object
+ *
+ * @param {string} localStringDate date string in the dd.mm.yyyy format
+ * @return {Date} converted date in UTC
+ */
+function localStringToDate(localStringDate) {
+  const dateParts = localStringDate.split('.');
+
+  return new Date(Date.UTC(dateParts[2], dateParts[1] - 1, dateParts[0]));
+}
+
+/**
+ * Resolves an element in the document using the provided selector
+ *
+ * @param {string} selector element selector
+ * @return {Promise.<HTMLElement>} promise for the html element
+ */
+async function resolveElement(selector) {
+  try {
+    return await htmlHelper.resolveElement(() =>
+      document.querySelector(selector));
+  } catch (error) {
+    extensionLogger.info(`Encountered an error on resolving element via 
+    '${selector}' selector:`, error);
+  }
+}
+
+/**
+ * Resolves elements in the document using the provided selector
+ *
+ * @param {string} selector element selector
+ * @return {Promise.<Array<HTMLElement>>} promise for the html elements
+ */
+async function resolveElements(selector) {
+  try {
+    return await htmlHelper.resolveElements(() =>
+      document.querySelectorAll(selector));
+  } catch (error) {
+    extensionLogger.info(`Encountered an error on resolving elements via 
+    '${selector}' selector:`, error);
+  }
+}
+
+export default {getId, getDescription, isInitialized, initialize, deregister};

--- a/src/helper/extension-logger.js
+++ b/src/helper/extension-logger.js
@@ -1,0 +1,41 @@
+import storageService from './storage-service.js';
+
+const LOGGING_DATA_STORAGE_KEY = 'logging';
+
+/**
+ * Logs an extension-specific message using the info level
+ *
+ * Message will be displayed only if the logging is enabled for the extension
+ *
+ * @param {string} message message to be logged
+ * @param {Array<object>} objects additional objects to be logged
+ */
+function info(message, objects) {
+  storageService.getGlobalData(LOGGING_DATA_STORAGE_KEY)
+      .then((debugData) => {
+        if (debugData.enabled) {
+          printMessage(console.log, message, objects);
+        }
+      });
+}
+
+/**
+ * Function that accepts a message for logging
+ *
+ * @callback logger
+ * @param {string} message message to be logged
+ * @param {Array<object>} objects additional objects to be logged
+ */
+
+/**
+ * Prints the message using the provided logger
+ *
+ * @param {logger} logger logger for printing the message
+ * @param {string} message message to be printed
+ * @param {Array<object>} objects additional objects to be logged
+ */
+function printMessage(logger, message, objects) {
+  logger(message, objects);
+}
+
+export default {info};

--- a/src/helper/html-helper.js
+++ b/src/helper/html-helper.js
@@ -1,7 +1,12 @@
+import {ResolutionTimeoutError} from './resolution-timeout-error.js';
+
+const ELEMENT_RESOLUTION_TIMEOUT_MS = 1000;
+
 /**
  * Function that returns html element or null if it's not available
  *
  * @callback elementSupplier
+ * @return {HTMLElement} html element
  */
 
 /**
@@ -14,7 +19,7 @@
  * @return {Promise.<HTMLElement>} promise for the html element
  */
 function resolveElement(elementSupplier) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const element = elementSupplier();
 
     if (element) {
@@ -24,13 +29,65 @@ function resolveElement(elementSupplier) {
     const observer = new MutationObserver((mutations) => {
       const element = elementSupplier();
       if (element) {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+
         resolve(element);
         observer.disconnect();
       }
     });
 
     observer.observe(document, {childList: true, subtree: true});
+    const timeout = setTimeout(() => {
+      observer.disconnect();
+      reject(new ResolutionTimeoutError());
+    }, ELEMENT_RESOLUTION_TIMEOUT_MS);
   });
 }
 
-export default {resolveElement};
+/**
+ * Function that returns html elements or null if they are not available
+ *
+ * @callback elementsSupplier
+ * @return {Array<HTMLElement>} html elements
+ */
+
+/**
+ * Resolves html element on the page
+ *
+ * Handles the cases when the element can't be retrieved right away
+ *
+ * @param {elementsSupplier} elementsSupplier provider of the html elements to
+ * resolve
+ * @return {Promise.<Array<HTMLElement>>} promise for the html elements
+ */
+function resolveElements(elementsSupplier) {
+  return new Promise((resolve, reject) => {
+    const elements = elementsSupplier();
+
+    if (elements.length > 0) {
+      return resolve(elements);
+    }
+
+    const observer = new MutationObserver((mutations) => {
+      const elements = elementsSupplier();
+      if (elements.length > 0) {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+
+        resolve(elements);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document, {childList: true, subtree: true});
+    const timeout = setTimeout(() => {
+      observer.disconnect();
+      reject(new ResolutionTimeoutError());
+    }, ELEMENT_RESOLUTION_TIMEOUT_MS);
+  });
+}
+
+export default {resolveElement, resolveElements};

--- a/src/helper/resolution-timeout-error.js
+++ b/src/helper/resolution-timeout-error.js
@@ -1,0 +1,11 @@
+/**
+ * HTML element resolution timed out error
+ */
+export class ResolutionTimeoutError extends Error {
+  /**
+   * Constructs new error instance
+   */
+  constructor() {
+    super('Failed to resolve an HTML element due to a timeout');
+  }
+}

--- a/src/helper/storage-service.js
+++ b/src/helper/storage-service.js
@@ -1,0 +1,56 @@
+const FEATURE_DATA_PREFIX = 'data';
+const GLOBAL_DATA_PREFIX = 'global';
+const KEY_DELIMITER = '.';
+
+/**
+ * Fetches feature-specific data from the storage using the key
+ *
+ * If there is no data in the storage with the provided key, empty object will
+ *  be returned in the response
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} dataKey feature-specific data key
+ * @return {Promise<Object>} promise for the feature-specific data object
+ */
+async function getFeatureData(featureId, dataKey) {
+  const key = FEATURE_DATA_PREFIX + KEY_DELIMITER + featureId +
+   KEY_DELIMITER + dataKey;
+  const settings = await browser.storage.sync.get(key);
+
+  return settings[key] || {};
+}
+
+/**
+ * Saves feature-specific data into the storage
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} dataKey feature-specific data key
+ * @param {object} data feature-specific data object to store
+ */
+function storeFeatureData(featureId, dataKey, data) {
+  const key = FEATURE_DATA_PREFIX + KEY_DELIMITER + featureId +
+   KEY_DELIMITER + dataKey;
+  const newData = {
+    [key]: data,
+  };
+
+  browser.storage.sync.set(newData);
+}
+
+/**
+ * Fetches global extension data from the storage using the key
+ *
+ * If there is no data in the storage with the provided key, empty object will
+ *  be returned in the response
+ *
+ * @param {string} dataKey data key
+ * @return {Promise<Object>} promise for the global data object
+ */
+async function getGlobalData(dataKey) {
+  const key = GLOBAL_DATA_PREFIX + KEY_DELIMITER + dataKey;
+  const settings = await browser.storage.local.get(key);
+
+  return settings[key] || {};
+}
+
+export default {getFeatureData, storeFeatureData, getGlobalData};


### PR DESCRIPTION
- add a new `projects-time` feature for extending the projects time summary window with grouped log entries
- set a 1000ms timeout for resolving elements via the html helper to avoid blocking for a long time
- provide the extension logger component for displaying log messages only if they are enabled for the extension, use it for some non-critical errors
- provide the storage service component to unify all storage-related interactions in one place(settings code remained unchanged for now)

Resolves https://github.com/Seregy/timedone-enhancement-suite/issues/8