### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci-on-branch.yaml
+++ b/.github/workflows/ci-on-branch.yaml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Build the extension
         uses: ./.github/actions/build-extension

--- a/.github/workflows/ci-on-tag.yaml
+++ b/.github/workflows/ci-on-tag.yaml
@@ -16,12 +16,12 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
 
       - name: Checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Build the extension
         uses: ./.github/actions/build-extension
@@ -36,7 +36,7 @@ jobs:
           AMO_API_SECRET: ${{ secrets.AMO_API_SECRET }}
       
       - name: Create new release
-        uses: softprops/action-gh-release@v0.1.13
+        uses: softprops/action-gh-release@v0.1
         with:
           draft: true
           files: "*/*.xpi"

--- a/.github/workflows/pages-deploy-on-push-main.yaml
+++ b/.github/workflows/pages-deploy-on-push-main.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v3
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@4
         with:
           branch: pages
           folder: pages

--- a/.github/workflows/push-update-manifest-on-release.yaml
+++ b/.github/workflows/push-update-manifest-on-release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v3
 
       - name: Extract xpi asset link from the event payload
         id: jq-stuff
@@ -28,9 +28,9 @@ jobs:
           ASSET_URL: ${{ steps.jq-stuff.outputs.value }}
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install npm dependencies
         run: npm ci
@@ -48,7 +48,7 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Create a pull request with the changes to the update manifest
-        uses: gr2m/create-or-update-pull-request-action@v1.3.0
+        uses: gr2m/create-or-update-pull-request-action@v1
         with:
           title: Add update entry for v${{ steps.extract-version.outputs.VERSION }}
           body: |


### PR DESCRIPTION
- update the versions of some GitHub actions to avoid deprecated warnings, use less specific versions to accept non-breaking updates