### PR TITLE
Fix softprops/action-gh-release action version

### DIFF
--- a/.github/workflows/ci-on-tag.yaml
+++ b/.github/workflows/ci-on-tag.yaml
@@ -41,3 +41,4 @@ jobs:
           draft: true
           files: "*/*.xpi"
           name: Release v${{ steps.extract-version.outputs.VERSION }}
+          generate_release_notes: true

--- a/.github/workflows/ci-on-tag.yaml
+++ b/.github/workflows/ci-on-tag.yaml
@@ -36,7 +36,7 @@ jobs:
           AMO_API_SECRET: ${{ secrets.AMO_API_SECRET }}
       
       - name: Create new release
-        uses: softprops/action-gh-release@v0.1
+        uses: softprops/action-gh-release@v0.1.15
         with:
           draft: true
           files: "*/*.xpi"


### PR DESCRIPTION
- fix the version for the `softprops/action-gh-release` GitHub action, as the currently specified one is not supported
- auto generate release notes on tag