### PR TITLE
Migrate the extension to manifest v3

### DIFF
--- a/src/action/action.js
+++ b/src/action/action.js
@@ -1,7 +1,13 @@
 import featureLoader from '../feature/feature-loader.js';
 
+const requiredPermissions = {
+  origins: ['*://timedone.golden-dimension.com/*'],
+};
+
+let permissionsGranted;
+
 /**
- * @typedef {import('./../feature/feature.js').Feature} Feature
+ * @typedef {import('../feature/feature.js').Feature} Feature
  */
 
 /**
@@ -34,6 +40,14 @@ function loadSettings() {
 
   const currentSettings = browser.storage.sync.get();
   currentSettings.then(applyCurrentValues, onStorageError);
+}
+
+/**
+ * Handles the change in feature's enable/disable status
+ */
+function handleFeatureStateChange() {
+  requestMissingPermissions();
+  saveSettings();
 }
 
 /**
@@ -80,7 +94,7 @@ function buildFeatureBlock(feature) {
   checkbox.classList.add('uk-checkbox');
   const featureId = feature.getId();
   checkbox.id = featureId;
-  checkbox.addEventListener('change', saveSettings);
+  checkbox.addEventListener('change', handleFeatureStateChange);
   container.appendChild(checkbox);
 
   const label = document.createElement('label');
@@ -90,6 +104,15 @@ function buildFeatureBlock(feature) {
   container.appendChild(label);
 
   return container;
+}
+
+/**
+ * Requests permissions necessary for the extension if needed
+ */
+async function requestMissingPermissions() {
+  if (!permissionsGranted) {
+    permissionsGranted = await browser.permissions.request(requiredPermissions);
+  }
 }
 
 initEventListeners();

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Timedone Enhancement Suite",
   "description": "Timedone Enhancement Suite",
   "version": "${version}",
@@ -10,17 +10,19 @@
       "css": ["content/content-script.css"]
     }
   ],
-  "browser_action": {
+  "action": {
     "default_popup": "action/index.html",
     "default_title": "Timedone Enhancement Suite"
   },
   "browser_specific_settings": {
     "gecko": {
       "id": "tes@seregy77.com",
-      "strict_min_version": "78.0",
+      "strict_min_version": "109.0",
       "update_url": "https://seregy.github.io/timedone-enhancement-suite/updates.json"
     }
   },
   "permissions": ["storage"],
-  "web_accessible_resources": ["fonts/*"]
+  "host_permissions": [
+    "*://timedone.golden-dimension.com/*"
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const devtool = 'cheap-source-map';
 const mode = 'production';
 const entry = {
   content: `./${SOURCE_DIRECTORY_NAME}/content-scripts/content-script.js`,
-  action: `./${SOURCE_DIRECTORY_NAME}/browser-action/action.js`,
+  action: `./${SOURCE_DIRECTORY_NAME}/action/action.js`,
 };
 const baseDirPath = _dirname(fileURLToPath(import.meta.url));
 const output = {
@@ -36,7 +36,7 @@ const module = {
             '@babel/preset-env',
             {
               targets: {
-                firefox: '78.0',
+                firefox: '109.0',
               },
             },
           ],


### PR DESCRIPTION
- upgrade the manifest version from v2 to v3
- rename `browser-action` into `action` to reflect the naming change in API
- raise the minimum firefox version to 109
- explicitly ask the user for host permissions on changing the feature settings as they're no longer granted on install
- remove unused `web_accessible_resources` from the manifest