### PR TITLE
Make the extension compatible with Chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "prettier": "^2.8.8",
         "prettier-eslint": "^15.0.1",
         "web-ext": "^7.6.2",
+        "webextension-polyfill": "^0.10.0",
         "webpack": "^5.88.1",
         "webpack-cli": "^5.1.4"
       }
@@ -11092,6 +11093,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==",
+      "dev": true
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -19825,6 +19832,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true
+    },
+    "webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==",
       "dev": true
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prettier": "^2.8.8",
     "prettier-eslint": "^15.0.1",
     "web-ext": "^7.6.2",
+    "webextension-polyfill": "^0.10.0",
     "webpack": "^5.88.1",
     "webpack-cli": "^5.1.4"
   },

--- a/privacy/chrome/extension-privacy-policy.md
+++ b/privacy/chrome/extension-privacy-policy.md
@@ -1,0 +1,5 @@
+# Privacy policy for the Timedone Enhancement Suite
+
+This extension does not collect personal or sensitive data.
+
+If the extension needs to get additional data from the Timedone server, it may utilize locally available access tokens. Access tokens are managed by the original web application and used by the extension only for making requests to the server. They won't not transmitted or stored anywhere else.

--- a/src/action/action.js
+++ b/src/action/action.js
@@ -1,4 +1,5 @@
 import featureLoader from '../feature/feature-loader.js';
+import browser from 'webextension-polyfill';
 
 const requiredPermissions = {
   origins: ['*://timedone.golden-dimension.com/*'],
@@ -87,7 +88,7 @@ function initEventListeners() {
  */
 function buildFeatureBlock(feature) {
   const container = document.createElement('div');
-  container.classList.add('uk-margin-small');
+  container.classList.add('uk-margin-small', 'uk-flex', 'uk-flex-middle');
 
   const checkbox = document.createElement('input');
   checkbox.setAttribute('type', 'checkbox');

--- a/src/content-scripts/content-script.js
+++ b/src/content-scripts/content-script.js
@@ -1,3 +1,4 @@
+import browser from 'webextension-polyfill';
 import featureInitializer from '../feature/feature-initializer.js';
 import UIkit from 'uikit';
 import Icons from 'uikit/dist/js/uikit-icons.js';

--- a/src/feature/expand-all/expand-all.css
+++ b/src/feature/expand-all/expand-all.css
@@ -1,8 +1,8 @@
-.tes-collapse-expand {
+#head .tes-collapse-expand {
   color: #fff;
   margin-right: 2rem;
 }
 
-.tes-collapse-expand:hover {
+#head .tes-collapse-expand:hover {
   color: #fff;
 }

--- a/src/feature/feature-initializer.js
+++ b/src/feature/feature-initializer.js
@@ -1,3 +1,4 @@
+import browser from 'webextension-polyfill';
 import featureLoader from './feature-loader.js';
 
 /**

--- a/src/feature/projects-time/projects-time.css
+++ b/src/feature/projects-time/projects-time.css
@@ -13,14 +13,14 @@
   background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%20%20%3Crect%20fill%3D%22%23666%22%20width%3D%2213%22%20height%3D%221%22%20x%3D%220%22%20y%3D%226%22%20%2F%3E%0A%3C%2Fsvg%3E");
 }
 
-.tes-pt-accordion-title > .worklog-project {
+.tes-pt-accordion-title > div.worklog-project {
   padding: 0;
   margin: 0.75rem 0;
 }
 
 .tes-pt-modal-container {
-  width: 75rem;
-  max-height: 75rem;
+  width: 75rem !important;
+  max-height: 75rem !important;
 }
 
 .tes-pt-group-title {

--- a/src/helper/storage-service.js
+++ b/src/helper/storage-service.js
@@ -1,3 +1,5 @@
+import browser from 'webextension-polyfill';
+
 const FEATURE_DATA_PREFIX = 'data';
 const GLOBAL_DATA_PREFIX = 'global';
 const KEY_DELIMITER = '.';

--- a/static/action/index.html
+++ b/static/action/index.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-  <div class="uk-container">
+  <div class="uk-container uk-margin-small-top">
     <form id="features"></form>
   </div>
 

--- a/static/action/style.css
+++ b/static/action/style.css
@@ -4,3 +4,8 @@
 body {
   background: #fafafa;
 }
+
+#features label {
+  white-space: nowrap;
+  display: inline-block;
+}

--- a/static/content/content-script.css
+++ b/static/content/content-script.css
@@ -1,2 +1,0 @@
-@import "content.css";
-@import "uikit.min.css";

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -7,7 +7,7 @@
     {
       "matches": ["*://timedone.golden-dimension.com/*"],
       "js": ["content/index.js"],
-      "css": ["content/content-script.css"]
+      "css": ["content/content.css", "content/uikit.min.css"]
     }
   ],
   "action": {


### PR DESCRIPTION
- add a `webextension-polyfill` dependency for cross-browser support
- adjust style classes and rules to deal with the display differences in Firefox and Chrome
- load css for content script separately, as Chrome doesn't seem to work with the single file with import statements
- add the extension privacy policy for the Chrome Web Store