### PR TITLE
Fix github-pages-deploy-action version

### DIFF
--- a/.github/workflows/pages-deploy-on-push-main.yaml
+++ b/.github/workflows/pages-deploy-on-push-main.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@4.4.3
         with:
           branch: pages
           folder: pages


### PR DESCRIPTION
- fix the `github-pages-deploy-action` action version, as the currently specified one is incorrect