### PR TITLE
Enable features by default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,9 @@ An unofficial browser extension that enhances the Timedone interface. Designed t
 ### Firefox
 
 Download and install the `.xpi` file from the [latest extension release](https://github.com/Seregy/timedone-enhancement-suite/releases/latest/). 
-
 It's signed by Mozilla and will be updated automatically.
+
+Please note that Firefox doesn't grant the necessary permissions to modify the pages' content upon installing the extension. You'll need to either temporarily grant them each time you visit Timedone or assign them once on a permanent basis.
 
 ### Chrome
 
@@ -29,6 +30,8 @@ Adjusts the way the footer element is [displayed on the page](docs/assets/footer
 Fixes the bug with the "Add new entry" modal window not selecting the project by default.
 
 This issue may appear when the web application attempts to load the last created log entry from the storage and fill in the values. The extension attempts to properly pick the last used project if it detects that the selection element is empty.
+
+Disabled by default, consider turning it on if you do experience issues with the project selection.
 
 ### Extended projects time summary
 

--- a/src/feature/expand-all/expand-all.js
+++ b/src/feature/expand-all/expand-all.js
@@ -43,6 +43,15 @@ function isInitialized() {
 }
 
 /**
+ * Returns whether the feature should be enabled by default
+ *
+ * @return {boolean} default enabled status
+ */
+function isEnabledByDefault() {
+  return true;
+}
+
+/**
  * Initializes and enables the feature
  */
 async function initialize() {
@@ -203,4 +212,5 @@ function handleSwitchToExpandableState() {
   }
 }
 
-export default {getId, getDescription, isInitialized, initialize, deregister};
+export default {getId, getDescription, isInitialized, isEnabledByDefault,
+  initialize, deregister};

--- a/src/feature/feature-initializer.js
+++ b/src/feature/feature-initializer.js
@@ -1,5 +1,6 @@
-import browser from 'webextension-polyfill';
 import featureLoader from './feature-loader.js';
+import featureService from '../helper/feature-service.js';
+import storageService from '../helper/storage-service.js';
 
 /**
  * @typedef {import('./../feature/feature.js').Feature} Feature
@@ -9,7 +10,7 @@ import featureLoader from './feature-loader.js';
  * Initializes all enabled features
  */
 function initializeFeatures() {
-  const featureSettingsPromise = loadFeatureSettings();
+  const featureSettingsPromise = storageService.getFeatureSettings();
   const features = featureLoader.getFeatures();
 
   const initStatusByFeature = new Map(features.map((feature) =>
@@ -29,15 +30,14 @@ function initializeFeatures() {
  *  with feature IDs as keys and their enabled status as values
  */
 function initializeFeature(feature, isInitialized, settings) {
-  const featureId = feature.getId();
-  const enabledInSettings = settings[featureId];
+  const enabled = featureService.isFeatureEnabled(feature, settings);
 
-  if (enabledInSettings && !isInitialized) {
+  if (enabled && !isInitialized) {
     feature.initialize();
     return;
   }
 
-  if (!enabledInSettings && isInitialized) {
+  if (!enabled && isInitialized) {
     feature.deregister();
   }
 }
@@ -49,15 +49,6 @@ function initializeFeature(feature, isInitialized, settings) {
 function onStorageError(error) {
   console.error(`Encountered an error on retrieving settings from the
    storage: ${error}`);
-}
-
-/**
- * Loads saved feature settings
- * @return {Promise.<Object.<string, boolean>>} promise for current feature
- *  settings object with feature IDs as keys and their enabled status as values
- */
-function loadFeatureSettings() {
-  return browser.storage.sync.get();
 }
 
 export default {initializeFeatures};

--- a/src/feature/feature.js
+++ b/src/feature/feature.js
@@ -36,6 +36,18 @@ export class Feature {
   }
 
   /**
+   * Returns whether the feature should be enabled by default
+   *
+   * Used to determine the feature status if the status hasn't been explicitly
+   *  set by a user
+   *
+   * @return {boolean} default enabled status
+   */
+  isEnabledByDefault() {
+    throw new Error('Not implemented');
+  }
+
+  /**
    * Initializes and enables the feature
    * @return {undefined}
    */

--- a/src/feature/footer-display-fix/footer-display-fix.js
+++ b/src/feature/footer-display-fix/footer-display-fix.js
@@ -38,6 +38,15 @@ function isInitialized() {
 }
 
 /**
+ * Returns whether the feature should be enabled by default
+ *
+ * @return {boolean} default enabled status
+ */
+function isEnabledByDefault() {
+  return true;
+}
+
+/**
  * Initializes and enables the feature
  */
 async function initialize() {
@@ -105,4 +114,5 @@ async function resolveElement(selector) {
   }
 }
 
-export default {getId, getDescription, isInitialized, initialize, deregister};
+export default {getId, getDescription, isInitialized, isEnabledByDefault,
+  initialize, deregister};

--- a/src/feature/project-autoselect-bugfix/project-autoselect-bugfix.js
+++ b/src/feature/project-autoselect-bugfix/project-autoselect-bugfix.js
@@ -38,6 +38,15 @@ function isInitialized() {
 }
 
 /**
+ * Returns whether the feature should be enabled by default
+ *
+ * @return {boolean} default enabled status
+ */
+function isEnabledByDefault() {
+  return false;
+}
+
+/**
  * Initializes and enables the feature
  */
 async function initialize() {
@@ -149,4 +158,5 @@ function selectProjectOption(projectSelectElement, projectValueToSelect) {
   projectSelectElement.dispatchEvent(new Event('change'));
 }
 
-export default {getId, getDescription, isInitialized, initialize, deregister};
+export default {getId, getDescription, isInitialized, isEnabledByDefault,
+  initialize, deregister};

--- a/src/feature/projects-time/projects-time.js
+++ b/src/feature/projects-time/projects-time.js
@@ -50,6 +50,15 @@ function isInitialized() {
 }
 
 /**
+ * Returns whether the feature should be enabled by default
+ *
+ * @return {boolean} default enabled status
+ */
+function isEnabledByDefault() {
+  return true;
+}
+
+/**
  * Initializes and enables the feature
  */
 async function initialize() {
@@ -172,7 +181,7 @@ async function modifyProjectsTimeEntries() {
 
   const modificationPromises = [];
   for (const [projectName, logLines] of logLinesByProjectNameSorted) {
-    const projectElement = await htmlHelper.resolveElement(() =>
+    const projectElement = await htmlHelper.resolveElementWithTimeout(() =>
       findWorklogProjectElement(projectName));
     const modificationPromise = modifyProjectTimeDetails(projectElement,
         projectName, logLines);
@@ -347,7 +356,7 @@ function localStringToDate(localStringDate) {
  */
 async function resolveElement(selector) {
   try {
-    return await htmlHelper.resolveElement(() =>
+    return await htmlHelper.resolveElementWithTimeout(() =>
       document.querySelector(selector));
   } catch (error) {
     extensionLogger.info(`Encountered an error on resolving element via 
@@ -363,7 +372,7 @@ async function resolveElement(selector) {
  */
 async function resolveElements(selector) {
   try {
-    return await htmlHelper.resolveElements(() =>
+    return await htmlHelper.resolveElementsWithTimeout(() =>
       document.querySelectorAll(selector));
   } catch (error) {
     extensionLogger.info(`Encountered an error on resolving elements via 
@@ -371,4 +380,5 @@ async function resolveElements(selector) {
   }
 }
 
-export default {getId, getDescription, isInitialized, initialize, deregister};
+export default {getId, getDescription, isInitialized, isEnabledByDefault,
+  initialize, deregister};

--- a/src/helper/feature-service.js
+++ b/src/helper/feature-service.js
@@ -1,0 +1,24 @@
+/**
+ * @typedef {import('../feature/feature.js').Feature} Feature
+ */
+
+/**
+ * Returns whether the provided feature should be enabled
+ *
+ * @param {Feature} feature to initialize
+ * @param {Object.<string, boolean>} settings feature settings object with
+ *  feature IDs as keys and their enabled status as values
+ * @return {boolean} feature enabled status
+ */
+function isFeatureEnabled(feature, settings) {
+  const featureId = feature.getId();
+  const enabledInSettings = settings[featureId];
+
+  if (enabledInSettings == null) {
+    return feature.isEnabledByDefault();
+  }
+
+  return enabledInSettings;
+}
+
+export default {isFeatureEnabled};

--- a/src/helper/html-helper.js
+++ b/src/helper/html-helper.js
@@ -19,6 +19,35 @@ const ELEMENT_RESOLUTION_TIMEOUT_MS = 1000;
  * @return {Promise.<HTMLElement>} promise for the html element
  */
 function resolveElement(elementSupplier) {
+  return new Promise((resolve) => {
+    const element = elementSupplier();
+
+    if (element) {
+      return resolve(element);
+    }
+
+    const observer = new MutationObserver(() => {
+      const element = elementSupplier();
+      if (element) {
+        resolve(element);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document, {childList: true, subtree: true});
+  });
+}
+
+/**
+ * Resolves html element on the page
+ *
+ * Handles the cases when the element can't be retrieved right away
+ *
+ * @param {elementSupplier} elementSupplier provider of the html element to
+ * resolve
+ * @return {Promise.<HTMLElement>} promise for the html element
+ */
+function resolveElementWithTimeout(elementSupplier) {
   return new Promise((resolve, reject) => {
     const element = elementSupplier();
 
@@ -26,7 +55,7 @@ function resolveElement(elementSupplier) {
       return resolve(element);
     }
 
-    const observer = new MutationObserver((mutations) => {
+    const observer = new MutationObserver(() => {
       const element = elementSupplier();
       if (element) {
         if (timeout) {
@@ -62,7 +91,7 @@ function resolveElement(elementSupplier) {
  * resolve
  * @return {Promise.<Array<HTMLElement>>} promise for the html elements
  */
-function resolveElements(elementsSupplier) {
+function resolveElementsWithTimeout(elementsSupplier) {
   return new Promise((resolve, reject) => {
     const elements = elementsSupplier();
 
@@ -70,7 +99,7 @@ function resolveElements(elementsSupplier) {
       return resolve(elements);
     }
 
-    const observer = new MutationObserver((mutations) => {
+    const observer = new MutationObserver(() => {
       const elements = elementsSupplier();
       if (elements.length > 0) {
         if (timeout) {
@@ -90,4 +119,5 @@ function resolveElements(elementsSupplier) {
   });
 }
 
-export default {resolveElement, resolveElements};
+export default {resolveElement, resolveElementWithTimeout,
+  resolveElementsWithTimeout};

--- a/src/helper/storage-service.js
+++ b/src/helper/storage-service.js
@@ -1,8 +1,36 @@
 import browser from 'webextension-polyfill';
 
+const FEATURE_STATUS_PREFIX = 'status';
 const FEATURE_DATA_PREFIX = 'data';
 const GLOBAL_DATA_PREFIX = 'global';
 const KEY_DELIMITER = '.';
+
+/**
+ * Fetches the feature status settings from the storage
+ *
+ * @return {Promise<Object<string, boolean>>} promise for feature status
+ *  settings with feature IDs as keys and their enabled status as values
+ */
+async function getFeatureSettings() {
+  const key = FEATURE_STATUS_PREFIX;
+  const settings = await browser.storage.sync.get(key);
+
+  return settings[key] || {};
+}
+
+/**
+ * Saves feature enabled settings into the storage
+ *
+ * @param {Object<string, boolean>} newSettings feature status settings to store
+ */
+async function storeFeatureSettings(newSettings) {
+  const key = FEATURE_STATUS_PREFIX;
+  const newData = {
+    [key]: newSettings,
+  };
+
+  browser.storage.sync.set(newData);
+}
 
 /**
  * Fetches feature-specific data from the storage using the key
@@ -55,4 +83,5 @@ async function getGlobalData(dataKey) {
   return settings[key] || {};
 }
 
-export default {getFeatureData, storeFeatureData, getGlobalData};
+export default {getFeatureSettings, storeFeatureSettings, getFeatureData,
+  storeFeatureData, getGlobalData};


### PR DESCRIPTION
- enable most of the features by default for the user convenience
- extract the feature status resolution into the `feature-service`
- finish the migration of storage-related functionality into the `storage-service`
- remove the timeout for the HTML element resolution in certain cases, rename the methods with timeouts for clarity
- refactor options script
- add a note regarding the Firefox permissions to the readme