### PR TITLE
Fix features initialization after switching pages

### DIFF
--- a/src/feature/expand-all/expand-all.js
+++ b/src/feature/expand-all/expand-all.js
@@ -72,6 +72,7 @@ async function initialize() {
 async function deregister() {
   const headerCell = await resolveHeaderCell();
   if (!headerCell) {
+    initialized = false;
     return;
   }
 

--- a/src/feature/feature-initializer.js
+++ b/src/feature/feature-initializer.js
@@ -23,6 +23,35 @@ function initializeFeatures() {
 }
 
 /**
+ * Repeats the initialization of all features
+ *
+ * Deregisters and then initializes enabled features
+ */
+async function reinitializeFeatures() {
+  const features = featureLoader.getFeatures();
+
+  const deregisterPromises = [];
+  features.forEach((feature) => {
+    const promise = deregisterFeature(feature);
+    deregisterPromises.push(promise);
+  });
+
+  await Promise.all(deregisterPromises);
+
+  initializeFeatures();
+}
+
+/**
+ * Initializes all enabled features
+ * @param {Feature} feature to initialize
+ */
+async function deregisterFeature(feature) {
+  if (feature.isInitialized()) {
+    feature.deregister();
+  }
+}
+
+/**
  * Initializes an enabled feature
  * @param {Feature} feature to initialize
  * @param {boolean} isInitialized current feature initialization status
@@ -51,4 +80,4 @@ function onStorageError(error) {
    storage: ${error}`);
 }
 
-export default {initializeFeatures};
+export default {initializeFeatures, reinitializeFeatures};

--- a/src/feature/projects-time/projects-time.css
+++ b/src/feature/projects-time/projects-time.css
@@ -20,7 +20,7 @@
 
 .tes-pt-modal-container {
   width: 75rem !important;
-  max-height: 75rem !important;
+  max-height: 90vh !important;
 }
 
 .tes-pt-group-title {

--- a/src/helper/storage-service.js
+++ b/src/helper/storage-service.js
@@ -1,5 +1,6 @@
 import browser from 'webextension-polyfill';
 
+const FEATURE_STATUS_STORAGE_AREA = 'sync';
 const FEATURE_STATUS_PREFIX = 'status';
 const FEATURE_DATA_PREFIX = 'data';
 const GLOBAL_DATA_PREFIX = 'global';
@@ -30,6 +31,36 @@ async function storeFeatureSettings(newSettings) {
   };
 
   browser.storage.sync.set(newData);
+}
+
+/**
+ * Function that will be called when the storage content changes
+ *
+ * @callback changeListener
+ */
+
+/**
+ * Adds a listener for the settings change event
+ *
+ * @param {changeListener} listener settings change listener
+ */
+function addFeatureSettingsChangeListener(listener) {
+  /**
+   * Handles generic storage changed events
+   *
+   * Triggers the listener only if the feature settings were actually changed
+   *
+   * @param {object} changes object describing the changes
+   * @param {string} areaName name of the storage area that got changed
+   */
+  function handleStorageChanged(changes, areaName) {
+    if (areaName === FEATURE_STATUS_STORAGE_AREA &&
+        !!changes[FEATURE_STATUS_PREFIX]) {
+      listener();
+    }
+  }
+
+  browser.storage.onChanged.addListener(handleStorageChanged);
 }
 
 /**
@@ -83,5 +114,6 @@ async function getGlobalData(dataKey) {
   return settings[key] || {};
 }
 
-export default {getFeatureSettings, storeFeatureSettings, getFeatureData,
-  storeFeatureData, getGlobalData};
+export default {getFeatureSettings, storeFeatureSettings,
+  addFeatureSettingsChangeListener, getFeatureData, storeFeatureData,
+  getGlobalData};

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -10,9 +10,6 @@
       "css": ["content/content.css", "content/uikit.min.css"]
     }
   ],
-  "action": {
-    "default_title": "Timedone Enhancement Suite"
-  },
   "options_ui": {
     "page": "option/index.html"
   },


### PR DESCRIPTION
- fix features not getting properly initialized after moving between different pages; use mutation observers for detecting the movement between pages
- use storage service in the content script for listening for the settings changes
- fix the extended projects time content not being scrollable if the window is small enough
- remove no longer used extension action button
- make sure the expand all feature gets deregistered even if elements are no longer on the page