### PR TITLE
Fix incorrect month in projects time entries

### DIFF
--- a/src/feature/projects-time/element/projects-time-element-builder.js
+++ b/src/feature/projects-time/element/projects-time-element-builder.js
@@ -403,7 +403,8 @@ function timeUnitsToString(timeUnits) {
  */
 function isoDateToString(isoDateString) {
   const dateParts = isoDateString.split('-');
-  const utcDate = new Date(Date.UTC(dateParts[0], dateParts[1], dateParts[2]));
+  const utcDate = new Date(Date.UTC(dateParts[0], dateParts[1] - 1,
+      dateParts[2]));
 
   return utcDate.toLocaleDateString('uk-UA');
 }


### PR DESCRIPTION
- fix an issue with projects time feature displaying time entry's dates as one month in the future