### PR TITLE
Fix the projects time feature initialization

### DIFF
--- a/src/helper/html-helper.js
+++ b/src/helper/html-helper.js
@@ -45,9 +45,11 @@ function resolveElement(elementSupplier) {
  *
  * @param {elementSupplier} elementSupplier provider of the html element to
  * resolve
+ * @param {number} timeoutMs timeout value in milliseconds
  * @return {Promise.<HTMLElement>} promise for the html element
  */
-function resolveElementWithTimeout(elementSupplier) {
+function resolveElementWithTimeout(elementSupplier,
+    timeoutMs = ELEMENT_RESOLUTION_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const element = elementSupplier();
 
@@ -71,7 +73,7 @@ function resolveElementWithTimeout(elementSupplier) {
     const timeout = setTimeout(() => {
       observer.disconnect();
       reject(new ResolutionTimeoutError());
-    }, ELEMENT_RESOLUTION_TIMEOUT_MS);
+    }, timeoutMs);
   });
 }
 

--- a/static/option/index.html
+++ b/static/option/index.html
@@ -6,7 +6,7 @@
   <link type="text/css" rel="stylesheet" href="style.css" media="screen,projection" />
 </head>
 
-<body>
+<body class="uk-container">
   <div class="uk-margin-left uk-margin-top">
     <h5>Features:</h5>
     <form id="features"></form>


### PR DESCRIPTION
- fix the projects time feature not properly replacing a modal window in some cases
- log more debug data in the projects time feature
- adjust `findWorklogProjectPair` in the `projects-time` to prevent accessing the property of an undefined object
- adjust `resolveElementWithTimeout` in the `html-helper` to allow specifying custom timeout values
- fix the heigh in the extension options page