### PR TITLE
Allow grouping logs by ticket in projects-time

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,9 +19,10 @@ This extension is available in the [Chrome Web Store](https://chrome.google.com/
 
 ### Extended projects time summary
 
-Extends the original projects' time summary modal window. Displays individual log entries for each project and allows grouping them by defining a regular expression to extract the group key.
+Extends the original projects' time summary modal window. Displays individual log entries for each project and allows grouping them either by a ticket value or by a description, using a regular expression to extract the group key.
 
-Provided regular expression must contain exactly one capturing group, which will be used to extract the grouping key. All log entries sharing the same extracted value will be placed in one group. If a log entry doesn't match the provided regex, it will be placed in the default group. If no regular expression is provided, all log entries will be placed in the default group.
+Regular expression for the description grouping must contain exactly one capturing group, which will be used to extract the grouping key from the description value. All log entries sharing the same extracted value will be placed in one group. If a log entry doesn't match the provided regex, it will be placed in the default group. If no regular expression is provided, all log entries will be placed in the default group.
 
 Specifying the group key extraction pattern allows grouping multiple entries by a [common keyword](docs/assets/projects-time/group-keyword.png?raw=1), [suffix](docs/assets/projects-time/group-suffix.png?raw=1), or the [whole description](docs/assets/projects-time/group-full-match.png?raw=1).
-Extraction patterns are specified and stored separately for each project.
+
+Grouping types and extraction patterns are specified and stored separately for each project.

--- a/src/api/api-client.js
+++ b/src/api/api-client.js
@@ -6,6 +6,7 @@ const API_PREFIX = 'https://timedone.gdnext.com/backend/api';
  * @typedef LogLine
  * @type {object}
  * @property {string} description log line description
+ * @property {string} ticket log line ticket
  * @property {string} logDate log line date in the yyyy-mm-dd format
  * @property {number} timeUnit integer amount of time units,
  *  1 unit is 30 minutes

--- a/src/feature/projects-time/collection-service.js
+++ b/src/feature/projects-time/collection-service.js
@@ -1,0 +1,17 @@
+/**
+ * Groups the array into a map by an extracted key
+ *
+ * @param {Array<T>} array array to be grouped
+ * @param {keyExtractor<T, K>} keyExtractor key extractor
+ * @return {Map<K, Array<T>>} grouped map
+ * @template T, K
+ */
+function groupToMap(array, keyExtractor) {
+  return array.reduce((map, arrayElement) => {
+    const key = keyExtractor(arrayElement);
+    map.get(key)?.push(arrayElement) ?? map.set(key, [arrayElement]);
+    return map;
+  }, new Map());
+}
+
+export default {groupToMap};

--- a/src/feature/projects-time/data/projects-time-data-storage.js
+++ b/src/feature/projects-time/data/projects-time-data-storage.js
@@ -1,6 +1,44 @@
 import storageService from '../../../helper/storage-service.js';
 
 const REGEX_DATA_STORAGE_KEY = 'regex';
+const GROUP_TYPE_STORAGE_KEY = 'group-type';
+
+
+/**
+ * Returns the current grouping type for the provided project
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} projectName project name to get the grouping type for
+ * @return {Promise<string>} promise for the grouping type value for the
+ *  project, if it exists
+ */
+async function getGroupTypeByProject(featureId, projectName) {
+  const storedGroupTypeData = await storageService.getFeatureData(featureId,
+      GROUP_TYPE_STORAGE_KEY);
+  const projectKey = convertProjectNameToKey(projectName);
+
+  return storedGroupTypeData[projectKey];
+}
+
+/**
+ * Saves a grouping type value for the provided project
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} projectName project name to save the grouping type for
+ * @param {string} newGroupingType grouping type value to save
+ */
+async function saveGroupTypeForProject(featureId, projectName,
+    newGroupingType) {
+  const projectKey = convertProjectNameToKey(projectName);
+  const storageKey = GROUP_TYPE_STORAGE_KEY;
+  const storedGroupTypeData = await storageService.getFeatureData(featureId,
+      storageKey);
+
+  storedGroupTypeData[projectKey] = newGroupingType;
+
+  storageService.storeFeatureData(featureId, storageKey,
+      storedGroupTypeData);
+}
 
 /**
  * Returns grouping regex value by the provided project
@@ -45,4 +83,5 @@ function convertProjectNameToKey(projectName) {
   return projectName.replaceAll(' ', '-');
 }
 
-export default {getGroupRegexByProject, saveGroupRegexForProject};
+export default {getGroupTypeByProject, saveGroupTypeForProject,
+  getGroupRegexByProject, saveGroupRegexForProject};

--- a/src/feature/projects-time/grouping-service.js
+++ b/src/feature/projects-time/grouping-service.js
@@ -1,0 +1,156 @@
+import dataStorage from './data/projects-time-data-storage.js';
+import collectionService from './collection-service.js';
+import extensionLogger from '../../helper/extension-logger.js';
+
+/**
+ * @typedef {import('./../../api/api-client.js').LogLine} LogLine
+ */
+
+/**
+ * Groups log lines by a grouping key
+ *
+ * Grouping key is extracted by a regular expression, associated with the
+ *  project. Two log line entries will be grouped together if regular expression
+ *  matches the same substring in the line description.
+ *
+ * @param {string} featureId ID of the projects-time feature
+ * @param {string} projectName name of the project, associated with the
+ * log lines
+ * @param {Array<LogLine>} logLines log lines to group
+ * @return {Promise<Map<string, Array<LogLine>>>} promise for the log lines
+ *  grouped by a grouping key
+ */
+async function groupLogLinesByGroupKey(featureId, projectName, logLines) {
+  const currentGroupingType =
+    await getCurrentGroupingType(featureId, projectName);
+
+  if (currentGroupingType === GroupType.DESCRIPTION) {
+    const groupRegexValue = await dataStorage.getGroupRegexByProject(featureId,
+        projectName);
+    const groupRegex = groupRegexValue ? new RegExp(groupRegexValue) : null;
+
+    return groupLogLinesByRegex(logLines, groupRegex);
+  }
+
+  return groupLogLinesByTicket(logLines);
+}
+
+/**
+ * Returns current grouping type for the project
+ *
+ * @param {string} featureId ID of the projects-time feature
+ * @param {string} projectName name of the project to get the grouping type for
+ * @return {Promise<string>} promise for the grouping type
+ */
+async function getCurrentGroupingType(featureId, projectName) {
+  const type = await dataStorage.getGroupTypeByProject(featureId, projectName);
+
+  return type ? mapToValidGroupType(featureId, type) : GroupType.DESCRIPTION;
+}
+
+/**
+ * Saves a new grouping type for the project
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} projectName project name to save the grouping type for
+ * @param {string} newGroupingType grouping type value to save
+ */
+async function saveCurrentGroupingType(featureId, projectName,
+    newGroupingType) {
+  const groupingTypeToSave = mapToValidGroupType(featureId, newGroupingType);
+  await dataStorage.saveGroupTypeForProject(featureId, projectName,
+      groupingTypeToSave);
+}
+
+/**
+ * Groups log lines by a regex grouping key
+ *
+ * @param {Array<LogLine>} logLines log lines to group
+ * @param {RegExp} regex regular expression for extracting the grouping key
+ * @return {Promise<Map<string, Array<LogLine>>>} promise for the log lines
+ *  grouped by a grouping key
+ */
+function groupLogLinesByRegex(logLines, regex) {
+  return collectionService.groupToMap(logLines,
+      (logLine) => extractGroupingKey(logLine, regex));
+}
+
+/**
+ * Extracts the grouping key from the log line entry
+ *
+ * @param {LogLine} logLine log line to extract the group from
+ * @param {RegExp} regex regular expression for extracting the grouping key
+ * @return {string | null} extracted grouping key or null if it couldn't be
+ *  extracted
+ */
+function extractGroupingKey(logLine, regex) {
+  if (regex == null) {
+    return null;
+  }
+
+  const description = logLine.description.trim();
+  const matchedResults = regex.exec(description);
+
+  if (matchedResults == null || matchedResults.length < 2) {
+    return null;
+  }
+
+  return matchedResults[1];
+}
+
+/**
+ * Groups log lines by the ticket value
+ *
+ * @param {Array<LogLine>} logLines log lines to group
+ * @return {Promise<Map<string, Array<LogLine>>>} promise for the log lines
+ *  grouped by a ticket
+ */
+function groupLogLinesByTicket(logLines) {
+  return collectionService.groupToMap(logLines,
+      (logLine) => extractTicketValue(logLine));
+}
+
+/**
+ * Extracts the ticket value from the log line entry
+ *
+ * @param {LogLine} logLine log line to extract the ticket from
+ * @return {string | null} extracted ticket value or null if it's not present
+ *  in the entry
+ */
+function extractTicketValue(logLine) {
+  const ticketValue = logLine.ticket;
+  if (!ticketValue) {
+    return null;
+  }
+
+  return ticketValue.trim();
+}
+
+/**
+ * Transforms a group type string into a valid type value
+ *
+ * Invalid values will be replaced with a default group type
+ *
+ * @param {string} featureId unique feature identifier
+ * @param {string} originalGroupType potentially invalid group type value
+ * @return {string} valid group type value
+ */
+function mapToValidGroupType(featureId, originalGroupType) {
+  if (originalGroupType === GroupType.DESCRIPTION ||
+        originalGroupType === GroupType.TICKET) {
+    return originalGroupType;
+  }
+
+  extensionLogger.infoFeature(featureId,
+      `Group type '${originalGroupType}' is invalid and will be substituted`);
+
+  return GroupType.DESCRIPTION;
+}
+
+const GroupType = {
+  DESCRIPTION: 'description',
+  TICKET: 'ticket',
+};
+
+export default {groupLogLinesByGroupKey, getCurrentGroupingType,
+  saveCurrentGroupingType, GroupType};

--- a/src/i18n/en/feature/index.js
+++ b/src/i18n/en/feature/index.js
@@ -9,8 +9,11 @@
 const enFeature = {
   projectTimeDuration: '{hours:number} h. {minutes:number} min.',
   projectTimeDefaultGroupName: 'Ungrouped',
+  projectTimeGroupingTypeTitle: 'Group by:',
+  projectTimeTicketGroupingType: 'ticket',
+  projectTimeDescriptionGroupingType: 'description',
   projectTimeRegexPlaceholder: 'Regex',
-  projectTimeRegexDescription: 'Regular expression for grouping records. Must contain exactly one capture group.',
+  projectTimeRegexDescription: 'Regular expression for grouping records by description. Must contain exactly one capture group.',
   projectTimeRegexErrorPrefix: 'Regular expression error.',
   projectTimeRegexTooManyGroupsError: 'Too many capture groups in the regular expression: actual amount - {actual:number}, expected - {expected:number}',
   projectTimeRegexNoGroupError: 'Regular expression must contain a capture group',

--- a/src/i18n/i18n-types.d.ts
+++ b/src/i18n/i18n-types.d.ts
@@ -30,11 +30,23 @@ export type NamespaceFeatureTranslation = {
 	 */
 	projectTimeDefaultGroupName: string
 	/**
+	 * G​r​o​u​p​ ​b​y​:
+	 */
+	projectTimeGroupingTypeTitle: string
+	/**
+	 * t​i​c​k​e​t
+	 */
+	projectTimeTicketGroupingType: string
+	/**
+	 * d​e​s​c​r​i​p​t​i​o​n
+	 */
+	projectTimeDescriptionGroupingType: string
+	/**
 	 * R​e​g​e​x
 	 */
 	projectTimeRegexPlaceholder: string
 	/**
-	 * R​e​g​u​l​a​r​ ​e​x​p​r​e​s​s​i​o​n​ ​f​o​r​ ​g​r​o​u​p​i​n​g​ ​r​e​c​o​r​d​s​.​ ​M​u​s​t​ ​c​o​n​t​a​i​n​ ​e​x​a​c​t​l​y​ ​o​n​e​ ​c​a​p​t​u​r​e​ ​g​r​o​u​p​.
+	 * R​e​g​u​l​a​r​ ​e​x​p​r​e​s​s​i​o​n​ ​f​o​r​ ​g​r​o​u​p​i​n​g​ ​r​e​c​o​r​d​s​ ​b​y​ ​d​e​s​c​r​i​p​t​i​o​n​.​ ​M​u​s​t​ ​c​o​n​t​a​i​n​ ​e​x​a​c​t​l​y​ ​o​n​e​ ​c​a​p​t​u​r​e​ ​g​r​o​u​p​.
 	 */
 	projectTimeRegexDescription: string
 	/**
@@ -75,11 +87,23 @@ export type TranslationFunctions = {
 		 */
 		projectTimeDefaultGroupName: () => LocalizedString
 		/**
+		 * Group by:
+		 */
+		projectTimeGroupingTypeTitle: () => LocalizedString
+		/**
+		 * ticket
+		 */
+		projectTimeTicketGroupingType: () => LocalizedString
+		/**
+		 * description
+		 */
+		projectTimeDescriptionGroupingType: () => LocalizedString
+		/**
 		 * Regex
 		 */
 		projectTimeRegexPlaceholder: () => LocalizedString
 		/**
-		 * Regular expression for grouping records. Must contain exactly one capture group.
+		 * Regular expression for grouping records by description. Must contain exactly one capture group.
 		 */
 		projectTimeRegexDescription: () => LocalizedString
 		/**

--- a/src/i18n/uk/feature/index.js
+++ b/src/i18n/uk/feature/index.js
@@ -9,8 +9,11 @@
 const ukFeature = {
   projectTimeDuration: '{hours:number} год. {minutes:number} хв.',
   projectTimeDefaultGroupName: 'Без групи',
+  projectTimeGroupingTypeTitle: 'Групувати за:',
+  projectTimeTicketGroupingType: 'номером задачі',
+  projectTimeDescriptionGroupingType: 'описом',
   projectTimeRegexPlaceholder: 'Regex',
-  projectTimeRegexDescription: 'Регулярний вираз для групування записів. Має містити рівно одну групу захоплення.',
+  projectTimeRegexDescription: 'Регулярний вираз для групування записів за описом. Має містити рівно одну групу захоплення.',
   projectTimeRegexErrorPrefix: 'Помилка в регулярному виразі.',
   projectTimeRegexTooManyGroupsError: 'Забагато груп захоплення в виразі: реальна кількість - {actual:number}, очікувана - {expected:number}',
   projectTimeRegexNoGroupError: 'Вираз має містити групу захоплення',


### PR DESCRIPTION
- add the option to group log entries by the ticket value instead of the description in the `projects-time` feature
- extract some methods from the `project-time.js` into the  `grouping-service.js` and the `collection-service.js`